### PR TITLE
Improve Unity verification code logging

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -24,10 +24,13 @@ function getHost(email) {
 }
 
 function parse(email, password, port, tls, savePath) {
+  const host = getHost(email);
+  console.log(`[unity-verify-code] Connecting to ${host}:${port} tls=${tls}`);
+
   const imap = new Imap({
     user: email,
     password: password,
-    host: getHost(email),
+    host: host,
     port: port,
     tls: tls,
     tlsOptions: {
@@ -36,19 +39,38 @@ function parse(email, password, port, tls, savePath) {
     authTimeout: 3000,
   });
 
-  imap.once('error', function (err) { console.log('Source Server Error:- ', err); });
+  imap.once('error', function (err) {
+    console.log('[unity-verify-code] Source Server Error:', err);
+  });
 
   imap.once('ready', function () {
+    console.log('[unity-verify-code] IMAP connection ready');
     imap.openBox('INBOX', false, function (err, box) {
-      if (err) throw err;
+      if (err) {
+        console.log('[unity-verify-code] Failed to open INBOX:', err);
+        throw err;
+      }
+      console.log('[unity-verify-code] INBOX opened');
       imap.search(['UNSEEN', ['OR', ['FROM', 'accounts@unity3d.com'], ['FROM', 'no-reply@unity3d.com']]], function (err, results) {
-        if (err) throw err;
+        if (err) {
+          console.log('[unity-verify-code] Search error:', err);
+          throw err;
+        }
+        if (!results || results.length === 0) {
+          console.log('[unity-verify-code] No unseen verification emails found');
+          console.log('[unity-verify-code] Closing IMAP connection');
+          return imap.end();
+        }
 
+        console.log(`[unity-verify-code] Found ${results.length} message(s)`);
+        console.log('[unity-verify-code] Fetching messages');
         let f = imap.fetch(results, { bodies: '', markSeen: true, });
         f.on('message', function(msg, seqno) {
           let prefix = '(#' + seqno + ') ';
+          console.log(`[unity-verify-code] Processing message ${prefix}`);
           msg.on('body', function(stream, info) {
             stream.on('data', function (chunk) {
+              console.log(`[unity-verify-code] Received ${chunk.length} bytes`);
               let content = chunk.toString('utf8');
 
               const patterns = [
@@ -80,10 +102,16 @@ function parse(email, password, port, tls, savePath) {
                 if (m) code = m[0];
               }
 
-              if (code)
+              if (code) {
+                console.log(`[unity-verify-code] Verification code: ${code}`);
+                console.log(`[unity-verify-code] Saving code to ${savePath}`);
                 fs.writeFileSync(savePath, code, { encoding: 'utf8' });
+              } else {
+                console.log('[unity-verify-code] Verification code not found in email body');
+              }
             });
 
+            console.log('[unity-verify-code] Closing IMAP connection');
             return imap.end();
           });
         });
@@ -92,6 +120,7 @@ function parse(email, password, port, tls, savePath) {
   });
 
   imap.connect();
+  console.log('[unity-verify-code] Connection initiated');
 }
 
 /*


### PR DESCRIPTION
## Summary
- improve parse.js log output for each step in retrieving the verification code
- handle empty search results before calling fetch

## Testing
- `npm test` *(fails: Error: no test specified)*