### PR TITLE
Replace console.log with log helper

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -10,14 +10,16 @@
 
 "use strict";
 
+function log(...args) { console.error(...args); }
+
 /**
  * Return true, if there is one invalid arguments.
  */
 function checkNull() {
-  console.log('[unity-verify-code] checkNull called with', arguments);
+  log('[unity-verify-code] checkNull called with', arguments);
   for (let index = 0; index < arguments.length; ++index) {
     if (!arguments[index]) {
-      console.log(`[unity-verify-code] Argument at index ${index} is null/undefined`);
+      log(`[unity-verify-code] Argument at index ${index} is null/undefined`);
       return true;
     }
   }
@@ -30,22 +32,22 @@ function checkNull() {
  * @param { any } defaultValue - Default value, this is for optional arguments.
  */
 function getArg(name, defaultValue = null) {
-  console.log(`[unity-verify-code] getArg called name=${name} default=${defaultValue}`);
+  log(`[unity-verify-code] getArg called name=${name} default=${defaultValue}`);
   let args = process.argv;
   if (typeof name === 'number') {
     let v = args[name];
-    console.log(`[unity-verify-code] getArg index ${name} => ${v}`);
+    log(`[unity-verify-code] getArg index ${name} => ${v}`);
     return v;
   } else {
     for (let index = 0; index < args.length; ++index) {
       if (args[index] === name && args.length > index + 1) {
         let v = args[index + 1];
-        console.log(`[unity-verify-code] getArg flag ${name} => ${v}`);
+        log(`[unity-verify-code] getArg flag ${name} => ${v}`);
         return v;
       }
     }
   }
-  console.log(`[unity-verify-code] getArg using default => ${defaultValue}`);
+  log(`[unity-verify-code] getArg using default => ${defaultValue}`);
   return defaultValue;
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -10,6 +10,8 @@
 
 "use strict";
 
+function log(...args) { console.error(...args); }
+
 const fs = require('fs');
 const parse = require('./parse');
 const args = require('./args');
@@ -32,26 +34,26 @@ const usage =
 
 /* CLI */
 const cli_md = function () {
-  console.log('[unity-verify-code] CLI started');
+  log('[unity-verify-code] CLI started');
   let email = args.getArg(2);
   let password = args.getArg(3);
   let savePath = args.getArg(4);
   let port = args.getArg("--port", 993);
   let tls = args.getArg("--tls", true);
 
-  console.log(`[unity-verify-code] email=${email} savePath=${savePath} port=${port} tls=${tls}`);
+  log(`[unity-verify-code] email=${email} savePath=${savePath} port=${port} tls=${tls}`);
 
   // Check valid arguments.
   if (args.checkNull(email, password, savePath)) {
-    console.log("[ERROR] Missing positional arguments");
-    console.log(usage);
+    log("[ERROR] Missing positional arguments");
+    log(usage);
     return;
   }
 
   parse.parse(email, password, port, tls, savePath)
-    .then(() => console.log('[unity-verify-code] CLI completed'))
+    .then(() => log('[unity-verify-code] CLI completed'))
     .catch(err => {
-      console.log('[unity-verify-code] CLI error', err);
+      log('[unity-verify-code] CLI error', err);
       process.exitCode = 1;
     });
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,18 +10,20 @@
 
 "use strict";
 
+function log(...args) { console.error(...args); }
+
 const fs = require('fs');
 let Imap;
 try {
   Imap = require('imap');
 } catch (e) {
-  console.log('[unity-verify-code] Failed to load imap module:', e.message);
+  log('[unity-verify-code] Failed to load imap module:', e.message);
   Imap = null;
 }
 const inspect = require('util').inspect;
 
 function getHost(email) {
-  console.log(`[unity-verify-code] getHost called with email: ${email}`);
+  log(`[unity-verify-code] getHost called with email: ${email}`);
   if (email.includes('@gmail.com')) return 'imap.gmail.com';
   if (email.includes('@hotmail.com')) return 'imap-mail.outlook.com';
   if (email.includes('@outlook.com')) return 'imap-mail.outlook.com';
@@ -32,10 +34,10 @@ function getHost(email) {
 }
 
 function parse(email, password, port, tls, savePath, ImapClass = Imap) {
-  console.log('[unity-verify-code] parse called');
-  console.log(`[unity-verify-code] email=${email} port=${port} tls=${tls} savePath=${savePath}`);
+  log('[unity-verify-code] parse called');
+  log(`[unity-verify-code] email=${email} port=${port} tls=${tls} savePath=${savePath}`);
   const host = getHost(email);
-  console.log(`[unity-verify-code] Connecting to ${host}:${port} tls=${tls}`);
+  log(`[unity-verify-code] Connecting to ${host}:${port} tls=${tls}`);
 
   const ImapImpl = ImapClass || Imap;
   if (!ImapImpl) {
@@ -56,43 +58,43 @@ function parse(email, password, port, tls, savePath, ImapClass = Imap) {
     });
 
     imap.once('error', function (err) {
-      console.log('[unity-verify-code] Source Server Error:', err);
+      log('[unity-verify-code] Source Server Error:', err);
       reject(err);
     });
 
     imap.once('end', function() {
-      console.log('[unity-verify-code] Connection ended');
+      log('[unity-verify-code] Connection ended');
       resolve();
     });
 
   imap.once('ready', function () {
-    console.log('[unity-verify-code] IMAP connection ready');
+    log('[unity-verify-code] IMAP connection ready');
     imap.openBox('INBOX', false, function (err, box) {
       if (err) {
-        console.log('[unity-verify-code] Failed to open INBOX:', err);
+        log('[unity-verify-code] Failed to open INBOX:', err);
         return reject(err);
       }
-      console.log('[unity-verify-code] INBOX opened');
+      log('[unity-verify-code] INBOX opened');
       imap.search(['UNSEEN', ['OR', ['FROM', 'accounts@unity3d.com'], ['FROM', 'no-reply@unity3d.com']]], function (err, results) {
         if (err) {
-          console.log('[unity-verify-code] Search error:', err);
+          log('[unity-verify-code] Search error:', err);
           return reject(err);
         }
         if (!results || results.length === 0) {
-          console.log('[unity-verify-code] No unseen verification emails found');
-          console.log('[unity-verify-code] Closing IMAP connection');
+          log('[unity-verify-code] No unseen verification emails found');
+          log('[unity-verify-code] Closing IMAP connection');
           return imap.end();
         }
 
-        console.log(`[unity-verify-code] Found ${results.length} message(s)`);
-        console.log('[unity-verify-code] Fetching messages');
+        log(`[unity-verify-code] Found ${results.length} message(s)`);
+        log('[unity-verify-code] Fetching messages');
         let f = imap.fetch(results, { bodies: '', markSeen: true, });
         f.on('message', function(msg, seqno) {
           let prefix = '(#' + seqno + ') ';
-          console.log(`[unity-verify-code] Processing message ${prefix}`);
+          log(`[unity-verify-code] Processing message ${prefix}`);
           msg.on('body', function(stream, info) {
             stream.on('data', function (chunk) {
-              console.log(`[unity-verify-code] Received ${chunk.length} bytes`);
+              log(`[unity-verify-code] Received ${chunk.length} bytes`);
               let content = chunk.toString('utf8');
 
               const patterns = [
@@ -125,15 +127,15 @@ function parse(email, password, port, tls, savePath, ImapClass = Imap) {
               }
 
               if (code) {
-                console.log(`[unity-verify-code] Verification code: ${code}`);
-                console.log(`[unity-verify-code] Saving code to ${savePath}`);
+                log(`[unity-verify-code] Verification code: ${code}`);
+                log(`[unity-verify-code] Saving code to ${savePath}`);
                 fs.writeFileSync(savePath, code, { encoding: 'utf8' });
               } else {
-                console.log('[unity-verify-code] Verification code not found in email body');
+                log('[unity-verify-code] Verification code not found in email body');
               }
             });
 
-            console.log('[unity-verify-code] Closing IMAP connection');
+            log('[unity-verify-code] Closing IMAP connection');
             return imap.end();
           });
         });
@@ -142,7 +144,7 @@ function parse(email, password, port, tls, savePath, ImapClass = Imap) {
   });
 
     imap.connect();
-    console.log('[unity-verify-code] Connection initiated');
+    log('[unity-verify-code] Connection initiated');
   });
 }
 


### PR DESCRIPTION
## Summary
- add a `log` helper in CLI, args, and parser modules
- redirect all console output to `console.error`

## Testing
- `node test/run-tests.js`